### PR TITLE
build: bump amd64 rocm and cpu bases to Ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 # ── Base images ───────────────────────────────────────────────────────────────
 #   amd64 + gpu:   NVIDIA CUDA 12.8 + cuDNN (GPU acceleration via NVIDIA Container Toolkit)
-#   amd64 + rocm:  Ubuntu 22.04 (AMD GPU via ROCm — pass /dev/kfd and /dev/dri)
+#   amd64 + rocm:  Ubuntu 26.04 (AMD GPU via ROCm — pass /dev/kfd and /dev/dri)
 #   amd64 + intel: Ubuntu 22.04 (Intel Arc / iGPU via OpenVINO — pass /dev/dri)
-#   amd64 + cpu:   Ubuntu 22.04 (CPU-only, ~2 GB smaller image)
+#                  Note: intel stays on 22.04 until Intel's GPU repo ships 26.04 packages
+#   amd64 + cpu:   Ubuntu 26.04 (CPU-only, ~2 GB smaller image)
 #   arm64:         Ubuntu 24.04 (CPU-only; no CUDA/ROCm wheels on ARM)
 
 ARG VARIANT=gpu
 
 FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS base-amd64-gpu
-FROM ubuntu:22.04 AS base-amd64-rocm
+FROM ubuntu:26.04 AS base-amd64-rocm
 FROM ubuntu:22.04 AS base-amd64-intel
-FROM ubuntu:22.04 AS base-amd64-cpu
+FROM ubuntu:26.04 AS base-amd64-cpu
 FROM ubuntu:24.04 AS base-arm64-gpu
 FROM ubuntu:24.04 AS base-arm64-rocm
 FROM ubuntu:24.04 AS base-arm64-intel
@@ -24,8 +25,9 @@ FROM base-${TARGETARCH}-${VARIANT} AS build
 ARG VARIANT=gpu
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Both Ubuntu 22.04 and 24.04 get Python 3.13 from the deadsnakes PPA.
-# GNUPGHOME is isolated so gpg never contacts an agent socket under QEMU.
+# All base images get Python 3.13 from the deadsnakes PPA (26.04 ships 3.14 natively;
+# 3.13 is used to keep dependencies tested and aligned). GNUPGHOME is isolated
+# so gpg never contacts an agent socket under QEMU.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl gnupg software-properties-common \
     && GNUPGHOME=$(mktemp -d) add-apt-repository ppa:deadsnakes/ppa -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # ── Base images ───────────────────────────────────────────────────────────────
-#   amd64 + gpu:   NVIDIA CUDA 12.8 + cuDNN (GPU acceleration via NVIDIA Container Toolkit)
+#   amd64 + gpu:   NVIDIA CUDA 12.8 + cuDNN on Ubuntu 24.04 (highest Ubuntu NVIDIA publishes)
 #   amd64 + rocm:  Ubuntu 26.04 (AMD GPU via ROCm — pass /dev/kfd and /dev/dri)
 #   amd64 + intel: Ubuntu 22.04 (Intel Arc / iGPU via OpenVINO — pass /dev/dri)
-#                  Note: intel stays on 22.04 until Intel's GPU repo ships 26.04 packages
+#                  Note: intel stays on 22.04 — Intel's GPU repo only publishes for jammy
 #   amd64 + cpu:   Ubuntu 26.04 (CPU-only, ~2 GB smaller image)
 #   arm64:         Ubuntu 24.04 (CPU-only; no CUDA/ROCm wheels on ARM)
 
 ARG VARIANT=gpu
 
-FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS base-amd64-gpu
+FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 AS base-amd64-gpu
 FROM ubuntu:26.04 AS base-amd64-rocm
 FROM ubuntu:22.04 AS base-amd64-intel
 FROM ubuntu:26.04 AS base-amd64-cpu


### PR DESCRIPTION
## Summary

- Bumps \`ubuntu:22.04\` → \`ubuntu:26.04\` for \`base-amd64-rocm\` and \`base-amd64-cpu\`
- Bumps CUDA GPU base from \`nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04\` → \`ubuntu24.04\` (highest NVIDIA publishes for CUDA 12.8.1)
- \`intel\` stays on \`22.04\` — Intel's GPU repo only publishes for \`jammy\`; 403 on \`noble\`, nothing for \`resolute\`
- \`arm64\` stays on \`24.04\` (unchanged)
- Python 3.13 still comes from the deadsnakes PPA; 26.04 ships 3.14 natively

## Tested locally

| Variant | Base | Result |
|---------|------|--------|
| cpu | ubuntu:26.04 (resolute) | ✓ built, 93/93 tests pass, all imports OK |
| gpu | cuda:12.8.1-ubuntu24.04 (noble) | ✓ built, CUDA+TensorRT providers registered |
| rocm | ubuntu:26.04 (resolute) | ✓ built |
| intel | ubuntu:22.04 (jammy) | unchanged — Intel repo has no newer packages |

## Why amd64 was never bumped

The ubuntu dependabot PR (#3) was auto-closed after arm64 was updated. amd64 non-GPU bases were overlooked. The arm64 revert was QEMU-specific (deadsnakes PPA GPG agent) — not applicable to native amd64 builds, already fixed via \`GNUPGHOME=\$(mktemp -d)\`.