### PR TITLE
fix: release workflow and docs for 0.5.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,9 +12,6 @@ on:
       - ".github/workflows/lint.yml"
       - ".github/dependabot.yml"
       - "uv.lock"
-      - "uv-cpu.lock"
-      - "uv-rocm.lock"
-      - "uv-intel.lock"
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,8 @@ jobs:
             exit 1
           fi
 
-      - name: Ensure lockfiles are current
-        run: |
-          cp pyproject.toml _pyproject_orig.toml
-          for variant in cpu rocm intel; do
-            cp pyproject-${variant}.toml pyproject.toml
-            uv lock
-            cp uv.lock uv-${variant}.lock
-          done
-          cp _pyproject_orig.toml pyproject.toml
-          uv lock
-          rm _pyproject_orig.toml
+      - name: Ensure lockfile is current
+        run: uv lock
 
       - name: Resolve tag name
         id: tag
@@ -117,15 +108,25 @@ jobs:
           script: |
             const tag = process.env.RELEASE_TAG;
             const notes = (process.env.RELEASE_NOTES || '').trim();
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: `Release ${tag}`,
-              body: notes || `Release ${tag}`,
-              draft: false,
-              prerelease: false,
-            });
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag,
+              });
+              console.log(`Release ${tag} already exists (id ${existing.data.id}), skipping creation.`);
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: `Release ${tag}`,
+                body: notes || `Release ${tag}`,
+                draft: false,
+                prerelease: false,
+              });
+            }
 
   build-images:
     name: Build and push Docker images

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Immich library
    ↳ at cap + QUALITY_REPLACEMENT=false — skip this person
 ```
 
-Uploaded and rejected asset IDs are persisted across runs. The same image is never processed twice; rejected assets are permanently skipped unless `RETRY_REJECTED=true`.
+Uploaded and rejected asset IDs are persisted across runs in a SQLite database (`winnow_tracker.db` in `CACHE_DIR`). The same image is never processed twice; rejected assets are permanently skipped unless `RETRY_REJECTED=true`.
 
 ---
 
@@ -213,7 +213,7 @@ These defaults are tuned for Frigate's ArcFace requirements. winnow will warn on
 | `FORCE_CPU` | `false` | Disable GPU — fall back to CPU for all inference |
 | `OPENVINO_DEVICE` | `CPU` | Intel variant only: set `GPU` to use Arc or iGPU; default runs on CPU |
 | `ENABLE_CACHE` | `true` | Cache computed embeddings to disk (speeds up re-runs on the same library) |
-| `CACHE_DIR` | `.if_cache` | Path for embedding cache and upload tracker files |
+| `CACHE_DIR` | `.if_cache` | Path for embedding cache and upload tracker database (`winnow_tracker.db`) |
 | `INSIGHTFACE_HOME` | *(system)* | InsightFace model cache path (Buffalo_L) |
 
 ### Output


### PR DESCRIPTION
Fixes the `release.yml` workflow that was failing on the v0.5.0 tag push because it still referenced the deleted per-variant pyproject/lockfiles.

## Changes

**`.github/workflows/release.yml`**
- "Ensure lockfiles are current" step: was looping over `pyproject-cpu/rocm/intel.toml` (deleted in 0.5.0) and writing `uv-cpu/rocm/intel.lock` (also deleted). Now simply runs `uv lock`.
- "Create GitHub Release": now checks if a release for the tag already exists before creating one, so re-triggered runs don't fail with a 422 conflict.

**`.github/workflows/docker-publish.yml`**  
- Removed `uv-cpu.lock`, `uv-rocm.lock`, `uv-intel.lock` from `paths-ignore` (files no longer exist).

**`README.md`**  
- `CACHE_DIR` description names the tracker file (`winnow_tracker.db`).
- Tracker sentence now says "SQLite database".