### PR TITLE
fix: release workflow for main (0.5.0 Docker builds)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,9 +12,6 @@ on:
       - ".github/workflows/lint.yml"
       - ".github/dependabot.yml"
       - "uv.lock"
-      - "uv-cpu.lock"
-      - "uv-rocm.lock"
-      - "uv-intel.lock"
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,8 @@ jobs:
             exit 1
           fi
 
-      - name: Ensure lockfiles are current
-        run: |
-          cp pyproject.toml _pyproject_orig.toml
-          for variant in cpu rocm intel; do
-            cp pyproject-${variant}.toml pyproject.toml
-            uv lock
-            cp uv.lock uv-${variant}.lock
-          done
-          cp _pyproject_orig.toml pyproject.toml
-          uv lock
-          rm _pyproject_orig.toml
+      - name: Ensure lockfile is current
+        run: uv lock
 
       - name: Resolve tag name
         id: tag
@@ -117,15 +108,25 @@ jobs:
           script: |
             const tag = process.env.RELEASE_TAG;
             const notes = (process.env.RELEASE_NOTES || '').trim();
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: `Release ${tag}`,
-              body: notes || `Release ${tag}`,
-              draft: false,
-              prerelease: false,
-            });
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag,
+              });
+              console.log(`Release ${tag} already exists (id ${existing.data.id}), skipping creation.`);
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: `Release ${tag}`,
+                body: notes || `Release ${tag}`,
+                draft: false,
+                prerelease: false,
+              });
+            }
 
   build-images:
     name: Build and push Docker images

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Immich library
    ↳ at cap + QUALITY_REPLACEMENT=false — skip this person
 ```
 
-Uploaded and rejected asset IDs are persisted across runs. The same image is never processed twice; rejected assets are permanently skipped unless `RETRY_REJECTED=true`.
+Uploaded and rejected asset IDs are persisted across runs in a SQLite database (`winnow_tracker.db` in `CACHE_DIR`). The same image is never processed twice; rejected assets are permanently skipped unless `RETRY_REJECTED=true`.
 
 ---
 
@@ -213,7 +213,7 @@ These defaults are tuned for Frigate's ArcFace requirements. winnow will warn on
 | `FORCE_CPU` | `false` | Disable GPU — fall back to CPU for all inference |
 | `OPENVINO_DEVICE` | `CPU` | Intel variant only: set `GPU` to use Arc or iGPU; default runs on CPU |
 | `ENABLE_CACHE` | `true` | Cache computed embeddings to disk (speeds up re-runs on the same library) |
-| `CACHE_DIR` | `.if_cache` | Path for embedding cache and upload tracker files |
+| `CACHE_DIR` | `.if_cache` | Path for embedding cache and upload tracker database (`winnow_tracker.db`) |
 | `INSIGHTFACE_HOME` | *(system)* | InsightFace model cache path (Buffalo_L) |
 
 ### Output


### PR DESCRIPTION
Merges the workflow fix from dev → main so the v0.5.0 Docker images can be triggered. Same changes as PR #17: remove per-variant lockfile loop from release.yml, remove stale paths-ignore entries from docker-publish.yml, SQLite tracker description in README.