### PR TITLE
fix: quality replacement slot floor uses deleted file's score not failed candidate's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-06-14
+
+### Fixed
+
+- **Quality replacement slot floor used wrong score**: when a blur-score replacement deleted a low-quality Frigate file but the subsequent upload failed, `min_quality_score_for_slot` was set to the failed candidate's score rather than the deleted file's score. This caused subsequent candidates that were better than the deleted file (but worse than the failed upload) to be skipped, leaving the freed slot unfilled for the rest of that run. Fixed by using `target_score` (deleted file's score) as the floor, matching the documented intent in the surrounding comment.
+
 ## [0.5.3] - 2026-06-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "winnow"
-version = "0.5.3"
+version = "0.5.4"
 description = "Selects diverse, high-quality photos from Immich as training data for Frigate face recognition."
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.13"

--- a/winnow/executor.py
+++ b/winnow/executor.py
@@ -464,7 +464,7 @@ def upload_to_frigate(jobs: list[dict]) -> None:
                         remove_frigate_file(name, target_frigate_file)
                         person_has_fscores = has_frigate_scores(name)
                         effective_count -= 1
-                        min_quality_score_for_slot = None if using_fscore else candidate_score
+                        min_quality_score_for_slot = None if using_fscore else target_score
                     else:
                         logger.warning("Failed to delete %s for %s, skipping replacement", target_frigate_file, name)
                         failed_deletes.add(target_frigate_file)


### PR DESCRIPTION
## Summary

Bug in the blur-score quality replacement path in `upload_to_frigate`.

When a Frigate file is deleted for quality replacement but the subsequent upload fails after all retries, `min_quality_score_for_slot` was set to `candidate_score` (the score of the file that failed to upload). The guard on the next iteration then required every subsequent candidate to beat that failed candidate's score — not just the deleted file's score.

**Example:**
- Deleted Frigate file: blur score 85 (worst in set)
- Candidate upload: blur score 92 → upload fails
- `min_quality_score_for_slot` set to **92** (wrong)
- Next candidate: blur score 88 → skipped (88 ≤ 92), even though 88 > 85 and is better than what we deleted
- Freed slot stays empty this run

**Fix:** use `target_score` (the deleted file's score) as the floor, which matches the comment that already correctly documents the intent: *"require the next candidate to beat the deleted file's score so the freed slot isn't filled with something worse than what we removed."*

One-line change: `candidate_score` → `target_score` on the assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)