### PR TITLE
fix: exclude main from lockfile update workflow trigger

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - '**'
+      - '!main'
     paths:
       - 'pyproject.toml'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- The `update-lockfile` workflow was triggering on pushes to `main` (via the `'**'` glob) and trying to push a commit directly to it
- `main` is protected and requires PRs, so the push was rejected with `GH006`
- Added `'!main'` exclusion to the branch filter — lockfile updates will still run on `dev` and feature branches where direct pushes are allowed

## Test plan

- [ ] Merge this to `dev`, then open a PR from `dev` to `main` and verify the `update-lockfile` workflow does **not** trigger on the `main` push