### PR TITLE
fix: exclude main from lockfile update workflow trigger

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - '**'
+      - '!main'
     paths:
       - 'pyproject.toml'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Merges the lockfile workflow fix from #36 into main
- The `update-lockfile` workflow was triggering on pushes to `main` and failing with `GH006` (protected branch)
- Added `'!main'` exclusion so the workflow only runs on branches where direct pushes are allowed

## Test plan

- [ ] Verify `update-lockfile` does not trigger on this merge to `main`